### PR TITLE
Add GitBook link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 **By [Eric Bezzam](https://ebezzam.github.io/), [Adrien Hoffet](https://people.epfl.ch/adrien.hoffet), and [Paolo Prandoni](https://people.epfl.ch/paolo.prandoni)**
 
-This repository contains the GitBook and associate code snippets for the [DSP4 module](https://www.coursera.org/learn/dsp4) of EPFL's Signal Processing MOOC hosted on Coursera. Please refer to the online class for details and to the introduction in this GitBook for details.
+This repository contains the GitBook and associate code snippets for the [DSP4 module](https://www.coursera.org/learn/dsp4) (log in required) of EPFL's Signal Processing MOOC hosted on Coursera. Please refer to the online class for details and to the introduction in this GitBook for details.
+
+Click [here](https://hwlab.learndsp.org/) to view the GitBook.
 
 If you refer to this material in your own work, please cite [our paper](https://infoscience.epfl.ch/record/258046/files/dsp_labs_icassp_2019.pdf).
 


### PR DESCRIPTION
I always find myself looking for this link, and think it would be useful here. Also when accessing the Coursera website without login it doesn't work, so I added a little note on that. 